### PR TITLE
Change unicast connection of dhcpv4 client as a raw socket

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
           go get -v -t ./...
           echo "" > "${GITHUB_WORKSPACE}"/coverage.txt
           for d in $(go list ./...); do
-              go test -v -race -coverprofile=profile.out -covermode=atomic "${d}"
+              sudo go test -v -race -coverprofile=profile.out -covermode=atomic "${d}"
               if [ -f profile.out ]; then
                 cat profile.out >> "${GITHUB_WORKSPACE}"/coverage.txt
                 rm profile.out

--- a/dhcpv4/nclient4/client.go
+++ b/dhcpv4/nclient4/client.go
@@ -214,7 +214,7 @@ func new(iface string, conn net.PacketConn, ifaceHWAddr net.HardwareAddr, opts .
 		if iface == `` {
 			return nil, ErrNoConn
 		}
-		c.conn, err = NewRawUDPConn(iface, ClientPort) // broadcast
+		c.conn, err = NewRawUDPConn(iface, &net.UDPAddr{Port: ClientPort}, UDPBroadcast) // broadcast
 		if err != nil {
 			return nil, fmt.Errorf("unable to open a broadcasting socket: %w", err)
 		}
@@ -349,15 +349,9 @@ func WithLogger(newLogger Logger) ClientOpt {
 // srcAddr is both:
 // * The source address of outgoing frames.
 // * The address to be listened for incoming frames.
-func WithUnicast(srcAddr *net.UDPAddr) ClientOpt {
+func WithUnicast(iface string, srcAddr *net.UDPAddr) ClientOpt {
 	return func(c *Client) (err error) {
-		if srcAddr == nil {
-			srcAddr = &net.UDPAddr{Port: ClientPort}
-		}
-		c.conn, err = net.ListenUDP("udp4", srcAddr)
-		if err != nil {
-			err = fmt.Errorf("unable to start listening UDP port: %w", err)
-		}
+		c.conn, err = NewRawUDPConn(iface, srcAddr, UDPUnicast)
 		return
 	}
 }

--- a/dhcpv4/nclient4/conn_unix_test.go
+++ b/dhcpv4/nclient4/conn_unix_test.go
@@ -1,0 +1,74 @@
+package nclient4
+
+import (
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	linkName = "neigh0"
+	ipStr    = "10.99.0.1"
+	macStr   = "aa:bb:cc:dd:00:01"
+)
+
+func TestGetHwAddrFromLocalCache(t *testing.T) {
+	mac, err := net.ParseMAC(macStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ip := net.ParseIP(ipStr)
+
+	if err := addNeigh(ip, mac); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := delNeigh(ip, mac); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	_, err = net.InterfaceByName(linkName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hw, err := getHwAddr(ip); err != nil && hw != nil && hw.String() == macStr {
+		t.Fatal(err)
+	}
+}
+
+func addNeigh(ip net.IP, mac net.HardwareAddr) error {
+	dummy := netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: linkName}}
+	if err := netlink.LinkAdd(&dummy); err != nil {
+		return err
+	}
+	newlink, err := netlink.LinkByName(dummy.Name)
+	if err != nil {
+		return err
+	}
+	dummy.Index = newlink.Attrs().Index
+
+	return netlink.NeighAdd(&netlink.Neigh{
+		LinkIndex:    dummy.Index,
+		State:        netlink.NUD_REACHABLE,
+		IP:           ip,
+		HardwareAddr: mac,
+	})
+}
+
+func delNeigh(ip net.IP, mac net.HardwareAddr) error {
+	dummy, err := netlink.LinkByName(linkName)
+	if err != nil {
+		return err
+	}
+
+	return netlink.NeighDel(&netlink.Neigh{
+		LinkIndex:    dummy.Attrs().Index,
+		State:        netlink.NUD_REACHABLE,
+		IP:           ip,
+		HardwareAddr: mac,
+	})
+}
+

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,14 @@ require (
 	github.com/fanliao/go-promise v0.0.0-20141029170127-1890db352a72
 	github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714
 	github.com/jsimonetti/rtnetlink v0.0.0-20201110080708-d2c240429e6c
+	github.com/mdlayher/arp v0.0.0-20191213142603-f72070a231fc
 	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7
 	github.com/mdlayher/netlink v1.1.1
 	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/u-root/uio v0.0.0-20210528114334-82958018845c
+	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,9 @@ github.com/jsimonetti/rtnetlink v0.0.0-20201110080708-d2c240429e6c h1:7cpGGTQO6+
 github.com/jsimonetti/rtnetlink v0.0.0-20201110080708-d2c240429e6c/go.mod h1:huN4d1phzjhlOsNIjFsw2SVRbwIHj3fJDMEU2SDPTmg=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/mdlayher/arp v0.0.0-20191213142603-f72070a231fc h1:m7rJJJeXrYCFpsxXYapkDW53wJCDmf9bsIXUg0HoeQY=
+github.com/mdlayher/arp v0.0.0-20191213142603-f72070a231fc/go.mod h1:eOj1DDj3NAZ6yv+WafaKzY37MFZ58TdfIhQ+8nQbiis=
+github.com/mdlayher/ethernet v0.0.0-20190313224307-5b5fc417d966/go.mod h1:5s5p/sMJ6sNsFl6uCh85lkFGV8kLuIYJCRJLavVJwvg=
 github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7 h1:lez6TS6aAau+8wXUP3G9I3TGlmPFEq2CTxBaRqY6AGE=
 github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7/go.mod h1:U6ZQobyTjI/tJyq2HG+i/dfSoFUt8/aZCM+GKtmFk/Y=
 github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
@@ -26,6 +29,7 @@ github.com/mdlayher/netlink v1.0.0/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqc
 github.com/mdlayher/netlink v1.1.0/go.mod h1:H4WCitaheIsdF9yOYu8CFmCgQthAPIWZmcKp9uZHgmY=
 github.com/mdlayher/netlink v1.1.1 h1:VqG+Voq9V4uZ+04vjIrcSCWDpf91B1xxbP4QBUmUJE8=
 github.com/mdlayher/netlink v1.1.1/go.mod h1:WTYpFb/WTvlRJAyKhZL5/uy69TDDpHHu2VZmb2XgV7o=
+github.com/mdlayher/raw v0.0.0-20190313224157-43dbcdd7739d/go.mod h1:r1fbeITl2xL/zLbVnNHFyOzQJTgr/3fpf1lJX/cjzR8=
 github.com/mdlayher/raw v0.0.0-20190606142536-fef19f00fc18/go.mod h1:7EpbotpCmVZcu+KCX4g9WaRNuu11uyhiW7+Le1dKawg=
 github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065 h1:aFkJ6lx4FPip+S+Uw4aTegFMct9shDvP+79PsSxpm3w=
 github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065/go.mod h1:7EpbotpCmVZcu+KCX4g9WaRNuu11uyhiW7+Le1dKawg=
@@ -41,9 +45,14 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/u-root/uio v0.0.0-20210528114334-82958018845c h1:BFvcl34IGnw8yvJi8hlqLFo9EshRInwWBs2M5fGWzQA=
 github.com/u-root/uio v0.0.0-20210528114334-82958018845c/go.mod h1:LpEX5FO/cB+WF4TYGY1V5qktpaZLkKkSegbr0V4eYXA=
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190313220215-9f648a60d977/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190419010253-1f3472d942ba/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
@@ -59,6 +68,7 @@ golang.org/x/sys v0.0.0-20190411185658-b44545bcd369/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190418153312-f0ce4c0180be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606122018-79a91cf218c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
If the network manager in the operating system uses DHCP to obtain an IP
for the network card, it will occupy the DHCP client port. In this case
the release function will fail because the unicast connection with UDP
socket needs the same port. Use a raw udp socket instead of a datagram
udp socket to solve it.

Signed-off-by: yaocw2020 <yaocanwu@gmail.com>